### PR TITLE
Add documentation for kubevirt-plugin usage/configuration

### DIFF
--- a/kubevirt/README.md
+++ b/kubevirt/README.md
@@ -1,15 +1,15 @@
-# headlamp-kubevirt
+# KubeVirt Plugin for Headlamp
+The **KubeVirt Plugin** is a [Headlamp](https://headlamp.dev/) extension that adds native support for managing [KubeVirt](https://kubevirt.io/) resources directly within the Headlamp UI. It enhances your Kubernetes dashboard with intuitive views and controls for managing Virtual Machines (VMs), Virtual Machine Instances (VMIs), and other KubeVirt-related resources.
 
-This is the default template README for [Headlamp Plugins](https://github.com/headlamp-k8s/headlamp).
 
-- The description of your plugin should go here.
-- You should also edit the package.json file meta data (like name and description).
+## 📋 Prerequisites
+- A running Kubernetes cluster with KubeVirt installed
+- VMs are deloyed with use of KubeVirt
 
-## Developing Headlamp plugins
+## 🚀 Installation Steps (On-Cluster Setup)
+Add an `initContainer` to the Headlamp deployment that copies the KubeVirt plugin files into a shared volume before the main Headlamp container starts.
 
-For more information on developing Headlamp plugins, please refer to:
+To install Headlamp, follow the instructions [here](https://headlamp.dev/docs/latest/installation/in-cluster/).
 
-- [Getting Started](https://headlamp.dev/docs/latest/development/plugins/), How to create a new Headlamp plugin.
-- [API Reference](https://headlamp.dev/docs/latest/development/api/), API documentation for what you can do
-- [UI Component Storybook](https://headlamp.dev/docs/latest/development/frontend/#storybook), pre-existing components you can use when creating your plugin.
-- [Plugin Examples](https://github.com/headlamp-k8s/headlamp/tree/main/plugins/examples), Example plugins you can look at to see how it's done.
+Before headlamp installation, update your manifest files or Helm values with the [these](./headlamp-values/) configuration:
+

--- a/kubevirt/README.md
+++ b/kubevirt/README.md
@@ -22,5 +22,5 @@ After applying the deployment changes, access Headlamp.
   Your browser does not support the video tag.
 </video>
 
-## Contact
+## 🙋 Contact
 For any questions or feedback, please open an issue on the GitHub repository.

--- a/kubevirt/README.md
+++ b/kubevirt/README.md
@@ -3,13 +3,24 @@ The **KubeVirt Plugin** is a [Headlamp](https://headlamp.dev/) extension that ad
 
 
 ## 📋 Prerequisites
-- A running Kubernetes cluster with KubeVirt installed
-- VMs are deloyed with use of KubeVirt
+- A running Kubernetes cluster with [KubeVirt installed](https://kubevirt.io/quickstart_kind/)
+- [VMs](https://kubevirt.io/user-guide/user_workloads/virtual_machine_instances/) are deloyed with use of KubeVirt
 
 ## 🚀 Installation Steps (On-Cluster Setup)
 Add an `initContainer` to the Headlamp deployment that copies the KubeVirt plugin files into a shared volume before the main Headlamp container starts.
 
 To install Headlamp, follow the instructions [here](https://headlamp.dev/docs/latest/installation/in-cluster/).
 
-Before headlamp installation, update your manifest files or Helm values with the [these](./headlamp-values/) configuration:
+Before headlamp installation, update your manifest files or Helm values with the [these](./headlamp-values/) configuration.
 
+## 🎥 Demo
+
+After applying the deployment changes, access Headlamp.
+
+<video width="640" height="360" controls>
+  <source src="./demo/Demo_KubeVirt_Plugin.mp4" type="video/mp4">
+  Your browser does not support the video tag.
+</video>
+
+## Contact
+For any questions or feedback, please open an issue on the GitHub repository.

--- a/kubevirt/headlamp-values/headlamp-deploy.yaml
+++ b/kubevirt/headlamp-values/headlamp-deploy.yaml
@@ -1,0 +1,42 @@
+
+# This file contains the deployment configuration for Headlamp, a web-based Kubernetes dashboard.
+
+# It includes the necessary configurations for the KubeVirt plugin, 
+# which allows users to manage KubeVirt resources directly from Headlamp.
+
+# The deployment file can be donwloaded from \
+# "https://raw.githubusercontent.com/kinvolk/headlamp/main/kubernetes-headlamp.yaml" and update with below content.
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: headlamp
+  namespace: kube-system
+spec:
+  # (Keep other fields the same as in the original deployment spec)
+  template:
+    spec:
+      volumes:
+        - name: plugin-volume
+          emptyDir: {}
+
+      initContainers:
+        - name: kubevirt-plugin
+          image: docker.io/praveen21b/kubevirt-plugin:v0.0.1-beta3
+          command:
+            - "/bin/sh"
+            - "-c"
+          args:
+            - cp -r /plugins/kubevirt/* /headlamp/plugins/kubevirt/
+          volumeMounts:
+            - name: plugin-volume
+              mountPath: /headlamp/plugins/kubevirt
+
+      containers:
+        - name: headlamp
+          # (Other container fields remain unchanged)
+          volumeMounts:
+            - name: plugin-volume
+              mountPath: /headlamp/plugins/kubevirt
+          # (Other container configuration stays the same)
+      # (Keep other fields the same as in the original deployment spec)

--- a/kubevirt/headlamp-values/helm-values.yaml
+++ b/kubevirt/headlamp-values/helm-values.yaml
@@ -1,0 +1,30 @@
+
+# This file contains the deployment configuration for Headlamp as helm values, a web-based Kubernetes dashboard.
+
+config:
+  pluginsDir: "/headlamp/plugins"
+  # -- Headlamp plugins directory
+
+# init containers
+initContainers:
+- name: kubevirt-plugin
+  image: docker.io/praveen21b/kubevirt-plugin:v0.0.1-beta3
+  command:
+  - "/bin/sh"
+  - "-c"
+  args:
+  - cp -r /plugins/kubevirt/* /headlamp/plugins/kubevirt/
+  volumeMounts:
+  - name: plugin-volume
+    mountPath: /headlamp/plugins/kubevirt
+
+
+# -- Headlamp containers volume mounts
+volumeMounts:
+- name: plugin-volume
+  mountPath: /headlamp/plugins/kubevirt
+
+# -- Headlamp pod's volumes
+volumes:
+- name: plugin-volume
+  emptyDir: {}


### PR DESCRIPTION
**Description:**

This PR adds documentation for the `kubevirt-plugin`, covering [briefly describe what's included — e.g., usage, configuration, deployment, integration with Headlamp, etc.].

**Key points:**
-  Provides step-by-step instructions for [setup/installation/configuration].
- Targets users integrating kubevirt into Headlamp.
- Includes [examples/screenshots/links to related config if applicable].

**Why it's needed:**

Currently, there is limited or no documentation within the plugin repo. This addition will help users and contributors understand how to use or extend the plugin.

**Additional notes:**

- Verified the plugin loads correctly under [Headlamp version 0.30.0 or K8s cluster version 1.30.0].
